### PR TITLE
root check via whoami

### DIFF
--- a/xmm2usb
+++ b/xmm2usb
@@ -5,7 +5,7 @@ die() {
 	exit 1
 }
 
-[ "${USER}" = root ] || die "must be run as root"
+[ "$(whoami)" = "root" ] || die "must be run as root"
 
 for path in `find /sys/devices/pci0000:00 -name vendor`; do
 	path="${path%/vendor}"


### PR DESCRIPTION
$USER is not defined when run from cron jobs or systemd units, it's better to use the output of "whoami" instead.